### PR TITLE
fatfs: fix multiple definitions of ff_rename when using ffmpeg

### DIFF
--- a/source/fatfs/ff.c
+++ b/source/fatfs/ff.c
@@ -4688,7 +4688,7 @@ FRESULT ff_mkdir (
 /* Rename a File/Directory                                               */
 /*-----------------------------------------------------------------------*/
 
-FRESULT ff_rename (
+FRESULT ff_rename_ (
 	const TCHAR* path_old,	/* Pointer to the object name to be renamed */
 	const TCHAR* path_new	/* Pointer to the new name */
 )

--- a/source/fatfs/ff.h
+++ b/source/fatfs/ff.h
@@ -284,7 +284,7 @@ FRESULT ff_findfirst (DIR* dp, FILINFO* fno, const TCHAR* path, const TCHAR* pat
 FRESULT ff_findnext (DIR* dp, FILINFO* fno);							/* Find next file */
 FRESULT ff_mkdir (const TCHAR* path);								/* Create a sub directory */
 FRESULT ff_unlink (const TCHAR* path);								/* Delete an existing file or directory */
-FRESULT ff_rename (const TCHAR* path_old, const TCHAR* path_new);	/* Rename/Move a file or directory */
+FRESULT ff_rename_ (const TCHAR* path_old, const TCHAR* path_new);	/* Rename/Move a file or directory */
 FRESULT ff_stat (const TCHAR* path, FILINFO* fno);					/* Get file status */
 FRESULT ff_chmod (const TCHAR* path, BYTE attr, BYTE mask);			/* Change attribute of a file/dir */
 FRESULT ff_utime (const TCHAR* path, const FILINFO* fno);			/* Change timestamp of a file/dir */

--- a/source/fatfs/ff_dev.c
+++ b/source/fatfs/ff_dev.c
@@ -439,7 +439,7 @@ static int ffdev_rename(struct _reent *r, const char *oldName, const char *newNa
     USBHSFS_LOG("Renaming \"%s\" (\"%s\") to \"%s\" (\"%s\").", oldName, old_path, newName, new_path);
     
     /* Rename entry. */
-    res = ff_rename(old_path, new_path);
+    res = ff_rename_(old_path, new_path);
     if (res != FR_OK) ff_set_error(ffdev_translate_error(res));
     
 end:


### PR DESCRIPTION
This fix duplicate definition of "ff_rename" when using ffmpeg (https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/avio.c#L673)