### PR TITLE
force correct library path for installing the static library

### DIFF
--- a/libntfs-3g/PKGBUILD
+++ b/libntfs-3g/PKGBUILD
@@ -26,7 +26,7 @@ build() {
 
   source /opt/devkitpro/switchvars.sh
 
-  ./configure --prefix="${PORTLIBS_PREFIX}" --host=aarch64-none-elf \
+  ./configure --prefix="${PORTLIBS_PREFIX}" --libdir="${PORTLIBS_PREFIX}/lib" --host=aarch64-none-elf \
     --disable-shared --enable-static --disable-device-default-io-ops \
     --disable-ntfs-3g --disable-ntfsprogs --disable-plugins --disable-crypto \
     --without-uuid --without-hd


### PR DESCRIPTION
* some linux systems have `lib64` configured as a directory for all the
  libraries, but devkitpro expects that the libraries are in `lib` with
  $PORTLIBS_PREFIX as a prefix.