### PR TITLE
Fixes for compilation/installation under Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,6 @@ ifeq ($(BUILD_TYPE),ISC)
 LIB_LICENSE	:=	ISC
 else
 LIB_LICENSE	:=	GPLv2+
-ifeq ($(MAKECMDGOALS),install)
-lib/lib$(TARGET).a: fs-libs
-lib/lib$(TARGET)d.a: fs-libs
-endif
 endif
 
 all: release debug

--- a/liblwext4/Makefile
+++ b/liblwext4/Makefile
@@ -1,7 +1,9 @@
 ifeq ($(OS),Windows_NT)
 MAKEPKG	:=	makepkg
 PACMAN	:=	pacman
+PACKAGES:=  patch dkp-toolchain-vars autotools tar bzip2 diffutils pkgconf
 else
+PACKAGES:=  patch dkp-toolchain-vars autoconf automake tar bzip2 diffutils pkgconf
 ifeq (,$(shell which makepkg))
 MAKEPKG	:=	dkp-makepkg
 else
@@ -21,5 +23,9 @@ all: deps
 	@$(MAKEPKG) -c -C -f -i -s --noconfirm > /dev/null
 
 deps:
-	-@$(PACMAN) -R pkg-config > /dev/null
-	@$(PACMAN) -S --needed --noconfirm patch dkp-toolchain-vars cmake tar bzip2 diffutils pkgconf > /dev/null
+ifeq ($(OS),Windows_NT)
+	@$(PACMAN) -R pkg-config > /dev/null
+endif
+	@for pkg in $(PACKAGES); do \
+		$(PACMAN) -Q $$pkg > /dev/null || $(PACMAN) -S --needed --noconfirm $$pkg; \
+	done

--- a/libntfs-3g/Makefile
+++ b/libntfs-3g/Makefile
@@ -1,7 +1,9 @@
 ifeq ($(OS),Windows_NT)
 MAKEPKG	:=	makepkg
 PACMAN	:=	pacman
+PACKAGES:=  patch dkp-toolchain-vars autotools tar bzip2 diffutils pkgconf
 else
+PACKAGES:=  patch dkp-toolchain-vars autoconf automake tar bzip2 diffutils pkgconf
 ifeq (,$(shell which makepkg))
 MAKEPKG	:=	dkp-makepkg
 else
@@ -21,5 +23,9 @@ all: deps
 	@$(MAKEPKG) -c -C -f -i -s --noconfirm > /dev/null
 
 deps:
-	-@$(PACMAN) -R pkg-config > /dev/null
-	@$(PACMAN) -S --needed --noconfirm patch dkp-toolchain-vars autotools tar bzip2 diffutils pkgconf > /dev/null
+ifeq ($(OS),Windows_NT)
+	@$(PACMAN) -R pkg-config > /dev/null
+endif
+	@for pkg in $(PACKAGES); do \
+		$(PACMAN) -Q $$pkg > /dev/null || $(PACMAN) -S --needed --noconfirm $$pkg; \
+	done


### PR DESCRIPTION
Hi,
Firstly, thanks again for the great and straightforward library.

Here are some changes to enable/streamline the installation on an Arch Linux host:
- Some of the packages the `deps` targets try to install do not exist on Arch, so I split those in lists depending on the host OS.
- Running `sudo -E make BUILD_TYPE=gpl install` will try to run `makepkg` as root, making it bail out and return an error. However, without root permissions, the installation cannot proceed. I "solved" this by removing the `fs-libs` dependency on the install target. This makes the installation accurate to the README (two separate steps to install the fs-libs, then the actual libusbhsfs library).

Additionally, some random thoughts:
- I think package management should be left to the user. So maybe test for the presence of the relevant executables, but IMO a Makefile installing packages is kind of intrusive. Additionally, I don't think it would work on non Arch-based Linux systems (dkp-pacman won't install stuff outside of the dkp repos).
- I find the event-based approach kind of awkward to program with. Either you want to poll (wait with timeout=0) regularly on your main thread, or spawn another thread which only waits and reacts to events, but that's kind of wasteful considering the library already runs in its own thread. Maybe a callback-based API would be more natural? The user could register functions that the library would call from its own thread. Perhaps I'm missing a design goal though...

What do you think?